### PR TITLE
Fix support for mkdocs 1.1

### DIFF
--- a/tags/plugin.py
+++ b/tags/plugin.py
@@ -13,7 +13,6 @@ from mkdocs.structure.files import File
 from mkdocs.structure.nav import Section
 from mkdocs.plugins import BasePlugin
 from mkdocs.config.config_options import Type
-from mkdocs.utils import string_types
 
 
 class TagsPlugin(BasePlugin):
@@ -25,9 +24,9 @@ class TagsPlugin(BasePlugin):
     """
 
     config_scheme = (
-        ('tags_filename', Type(string_types, default='tags.md')),
-        ('tags_folder', Type(string_types, default='aux')),
-        ('tags_template', Type(string_types)),
+        ('tags_filename', Type(str, default='tags.md')),
+        ('tags_folder', Type(str, default='aux')),
+        ('tags_template', Type(str)),
     )
 
     def __init__(self):


### PR DESCRIPTION
MkDocs 1.1 dropped `string_types`

See https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/8